### PR TITLE
Unilang

### DIFF
--- a/brogger/brog.go
+++ b/brogger/brog.go
@@ -347,7 +347,7 @@ func (b *Brog) setLangCookie(req *http.Request, rw http.ResponseWriter) {
 	lang := req.URL.RawQuery
 	_, err := req.Cookie("lang")
 	if lang != "" && (err != nil || strings.HasSuffix(req.Referer(), "/changelang")) {
-		rw.Header().Add("Set-Cookie", "lang="+lang)
+		rw.Header().Add("Set-Cookie", "lang="+lang+";Path=/")
 	}
 }
 


### PR DESCRIPTION
Simple fixes.
One is for the unilang "fix". 'Twas a three line fix, not a two line one.
One is to avoid showing the user the language selection screen multiple times.
