### PR TITLE
Add gzip middleware

### DIFF
--- a/brogger/gzip.go
+++ b/brogger/gzip.go
@@ -1,0 +1,15 @@
+package brogger
+
+import (
+	"io"
+	"net/http"
+)
+
+type gzipResponseWriter struct {
+	io.Writer
+	http.ResponseWriter
+}
+
+func (w gzipResponseWriter) Write(b []byte) (int, error) {
+	return w.Writer.Write(b)
+}


### PR DESCRIPTION
Only compresses assets. Adds gzipHandler and gzipResponseWriter. Doesn't use middlewares because assets appears to be a special case.
