### PR TITLE
Removed reliance on deprecated code.

### DIFF
--- a/brogger/post.go
+++ b/brogger/post.go
@@ -119,7 +119,6 @@ func markdownWithHTML(input []byte) []byte {
 	htmlFlags |= blackfriday.HTML_USE_SMARTYPANTS
 	htmlFlags |= blackfriday.HTML_SMARTYPANTS_FRACTIONS
 	htmlFlags |= blackfriday.HTML_SMARTYPANTS_LATEX_DASHES
-	htmlFlags |= blackfriday.HTML_GITHUB_BLOCKCODE
 	renderer := blackfriday.HtmlRenderer(htmlFlags, "", "")
 
 	// set up the parser


### PR DESCRIPTION
`post.go:122` originally referenced `HTML_GITHUB_BLOCKCODE` from
`russross/blackfriday`, but this variable is no longer exposed in the
current revisions of the package.

Originally this set a value in a bit field controlling how code blocks
are rendered by Markdown. Removing this looks like it's a non-breaking
change because the `blackfriday` code now falls back onto a GitHub theme
anyway.

Tested locally; works with triple-backtick (<code>```</code>),
language-specified triple-backtick (<code>```python</code>) blocks, as well as
code blocks indented with four or more spaces.

Original commit which integrated the change into `russross/blackfriday`
can be found here: [`9328516`](https://github.com/russross/blackfriday/commit/67002b01b615af4456e1bb362d11002a57e32c1f).
